### PR TITLE
Move Random.swift to the SwiftGraphics target.

### DIFF
--- a/SwiftGraphics.xcodeproj/project.pbxproj
+++ b/SwiftGraphics.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		02C9D0121A71D12F00B9696E /* RegularPolygon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C9D0111A71D12F00B9696E /* RegularPolygon.swift */; };
 		02C9D0131A71D12F00B9696E /* RegularPolygon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C9D0111A71D12F00B9696E /* RegularPolygon.swift */; };
 		02C9D0261A724D9C00B9696E /* RegularPolygonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C9D0251A724D9C00B9696E /* RegularPolygonTests.swift */; };
+		02E8FBC41A8615B90061D101 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E8FBC31A8615B90061D101 /* Random.swift */; };
+		02E8FBC51A8615B90061D101 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E8FBC31A8615B90061D101 /* Random.swift */; };
 		2E0F5BD91A6986DA00221BB0 /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0F5BD81A6986DA00221BB0 /* ColorTests.swift */; };
 		2E0F5BDB1A69BBA600221BB0 /* QuadrantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0F5BDA1A69BBA600221BB0 /* QuadrantTests.swift */; };
 		2E0F5BDD1A69C43A00221BB0 /* UtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0F5BDC1A69C43A00221BB0 /* UtilitiesTests.swift */; };
@@ -158,7 +160,6 @@
 		45B32D511A637EE7004FD3FB /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B32D501A637EE7004FD3FB /* Utilities.swift */; };
 		45B32D531A637F10004FD3FB /* OmniGraffle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B32D521A637F10004FD3FB /* OmniGraffle.swift */; };
 		45B78E631A7702F80058B3A0 /* Scratch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B78E621A7702F80058B3A0 /* Scratch.swift */; };
-		45B8787C1A634F1F00CE168E /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B8787B1A634F1F00CE168E /* Random.swift */; };
 		45B8AE8E19BCE4ED00C61A3F /* CColorConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 45563F2D19B1047E003B1639 /* CColorConverter.m */; };
 		45BA25B819CA112E00B612B7 /* MonotoneChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BA25B719CA112E00B612B7 /* MonotoneChain.swift */; };
 		45BA25BD19CA1E8A00B612B7 /* ConvexHullTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BA25BC19CA1E8A00B612B7 /* ConvexHullTests.swift */; };
@@ -285,6 +286,7 @@
 		02BF437D1A64FACB00132343 /* BezierCurve+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BezierCurve+Extensions.swift"; sourceTree = "<group>"; };
 		02C9D0111A71D12F00B9696E /* RegularPolygon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegularPolygon.swift; sourceTree = "<group>"; };
 		02C9D0251A724D9C00B9696E /* RegularPolygonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegularPolygonTests.swift; sourceTree = "<group>"; };
+		02E8FBC31A8615B90061D101 /* Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Random.swift; sourceTree = "<group>"; };
 		2E0F5BD81A6986DA00221BB0 /* ColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
 		2E0F5BDA1A69BBA600221BB0 /* QuadrantTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuadrantTests.swift; sourceTree = "<group>"; };
 		2E0F5BDC1A69C43A00221BB0 /* UtilitiesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilitiesTests.swift; sourceTree = "<group>"; };
@@ -395,7 +397,6 @@
 		45B32D501A637EE7004FD3FB /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		45B32D521A637F10004FD3FB /* OmniGraffle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OmniGraffle.swift; sourceTree = "<group>"; };
 		45B78E621A7702F80058B3A0 /* Scratch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scratch.swift; sourceTree = "<group>"; };
-		45B8787B1A634F1F00CE168E /* Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Random.swift; sourceTree = "<group>"; };
 		45BA25B719CA112E00B612B7 /* MonotoneChain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonotoneChain.swift; sourceTree = "<group>"; };
 		45BA25BB19CA156800B612B7 /* Triangle.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Triangle.playground; sourceTree = "<group>"; };
 		45BA25BC19CA1E8A00B612B7 /* ConvexHullTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConvexHullTests.swift; sourceTree = "<group>"; };
@@ -502,7 +503,6 @@
 			isa = PBXGroup;
 			children = (
 				45CFDC651A61CA0700053F96 /* Utilities.swift */,
-				45B8787B1A634F1F00CE168E /* Random.swift */,
 				45B32D4E1A637ECC004FD3FB /* RegularExpression.swift */,
 			);
 			name = "Non-Graphics";
@@ -784,6 +784,7 @@
 		458C59031A740A7D00E993A6 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				02E8FBC31A8615B90061D101 /* Random.swift */,
 				4515825B19C9F21000856C91 /* Turn.swift */,
 				459EE5E519AEC5130012E023 /* Scaling.swift */,
 				456877E119B6857B004BEFD6 /* CoordinateSystems.swift */,
@@ -1214,6 +1215,7 @@
 				45563F2F19B1047E003B1639 /* CColorConverter.m in Sources */,
 				02C9D0121A71D12F00B9696E /* RegularPolygon.swift in Sources */,
 				45066D001A743BD400F561E1 /* Triangle+Markup.swift in Sources */,
+				02E8FBC41A8615B90061D101 /* Random.swift in Sources */,
 				45FA46511A7F3DBB000473B5 /* Rectangle+Markup.swift in Sources */,
 				459EE5F919AEC5130012E023 /* Scaling.swift in Sources */,
 				459EE5F719AEC5130012E023 /* Quadrant.swift in Sources */,
@@ -1272,7 +1274,6 @@
 				45CFDC661A61CA0700053F96 /* Utilities.swift in Sources */,
 				45B32D4F1A637ECD004FD3FB /* RegularExpression.swift in Sources */,
 				45B32D4A1A637DF3004FD3FB /* Sketch.swift in Sources */,
-				45B8787C1A634F1F00CE168E /* Random.swift in Sources */,
 				45B32D481A637DF3004FD3FB /* Arc.swift in Sources */,
 				453A8FBD1A69DFC000D7EAD0 /* Silly.swift in Sources */,
 				450717091A6B7F0700E86EB4 /* CGTypes+String.swift in Sources */,
@@ -1360,6 +1361,7 @@
 				45F5CE211A74094000F4B15D /* AssociatedObjects+Private.swift in Sources */,
 				02AAA8EE1A7A16A5001898E2 /* Gradient.swift in Sources */,
 				458C590C1A74121600E993A6 /* CGContext+Drawing.swift in Sources */,
+				02E8FBC51A8615B90061D101 /* Random.swift in Sources */,
 				4563EFDA1A7E9B7000019643 /* Matrix.swift in Sources */,
 				459EE5FA19AEC5130012E023 /* Scaling.swift in Sources */,
 				459EE5F819AEC5130012E023 /* Quadrant.swift in Sources */,

--- a/SwiftGraphics.xcodeproj/project.pbxproj
+++ b/SwiftGraphics.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				02B1D63E1A864D0D00734945 /* PBXTargetDependency */,
 				4514F5F91A61D2EE00CC9C26 /* PBXTargetDependency */,
 				454FE67C19C77094002E4DEF /* PBXTargetDependency */,
 				45B8AE9419BCE57900C61A3F /* PBXTargetDependency */,
@@ -206,6 +207,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		02B1D63D1A864D0D00734945 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 454D54FE19AA5CE6000E3EB3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 455AC2C21A76130B00BCC373;
+			remoteInfo = SwiftGraphics_OSX_Scratch;
+		};
 		4514F5F81A61D2EE00CC9C26 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 454D54FE19AA5CE6000E3EB3 /* Project object */;
@@ -1391,6 +1399,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		02B1D63E1A864D0D00734945 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 455AC2C21A76130B00BCC373 /* SwiftGraphics_OSX_Scratch */;
+			targetProxy = 02B1D63D1A864D0D00734945 /* PBXContainerItemProxy */;
+		};
 		4514F5F91A61D2EE00CC9C26 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 45CFDC9D1A61CE3500053F96 /* SwiftGraphics_OSX_UITest */;

--- a/SwiftGraphics.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/SwiftGraphics.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -32,16 +32,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4501557E1A62F9F600D7FB7B"
-               BuildableName = "SwiftGraphicsPlayground_OSX_UnitTests.xctest"
-               BlueprintName = "SwiftGraphicsPlayground_OSX_UnitTests"
-               ReferencedContainer = "container:SwiftGraphics.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "454D551119AA5CE6000E3EB3"
                BuildableName = "SwiftGraphicsTests.xctest"
                BlueprintName = "SwiftGraphicsTests"

--- a/SwiftGraphics.xcodeproj/xcshareddata/xcschemes/SwiftGraphicsPlayground.xcscheme
+++ b/SwiftGraphics.xcodeproj/xcshareddata/xcschemes/SwiftGraphicsPlayground.xcscheme
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:SwiftGraphics.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4501557E1A62F9F600D7FB7B"
-               BuildableName = "SwiftGraphicsPlayground_OSX_UnitTests.xctest"
-               BlueprintName = "SwiftGraphicsPlayground_OSX_UnitTests"
-               ReferencedContainer = "container:SwiftGraphics.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -49,16 +35,6 @@
                BlueprintIdentifier = "454D551119AA5CE6000E3EB3"
                BuildableName = "SwiftGraphicsTests.xctest"
                BlueprintName = "SwiftGraphicsTests"
-               ReferencedContainer = "container:SwiftGraphics.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4501557E1A62F9F600D7FB7B"
-               BuildableName = "SwiftGraphicsPlayground_OSX_UnitTests.xctest"
-               BlueprintName = "SwiftGraphicsPlayground_OSX_UnitTests"
                ReferencedContainer = "container:SwiftGraphics.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/SwiftGraphics.xcodeproj/xcshareddata/xcschemes/SwiftGraphics_OSX.xcscheme
+++ b/SwiftGraphics.xcodeproj/xcshareddata/xcschemes/SwiftGraphics_OSX.xcscheme
@@ -52,16 +52,6 @@
                ReferencedContainer = "container:SwiftGraphics.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4501557E1A62F9F600D7FB7B"
-               BuildableName = "SwiftGraphicsPlayground_OSX_UnitTests.xctest"
-               BlueprintName = "SwiftGraphicsPlayground_OSX_UnitTests"
-               ReferencedContainer = "container:SwiftGraphics.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/SwiftGraphics/CGContext+Drawing.swift
+++ b/SwiftGraphics/CGContext+Drawing.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 schwa.io. All rights reserved.
 //
 
-import Foundation
+import CoreGraphics
 
 // TODO: Deprecate. Most of this will be deprecated and replaced by the Drawable API. #deprecate #simplify
 public extension CGContext {

--- a/SwiftGraphics/GeometryProtocols.swift
+++ b/SwiftGraphics/GeometryProtocols.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 schwa.io. All rights reserved.
 //
 
-import Foundation
+import CoreGraphics
 
 public protocol Geometry {
     var frame:CGRect { get }

--- a/SwiftGraphics/Random.swift
+++ b/SwiftGraphics/Random.swift
@@ -8,6 +8,8 @@
 
 // MARK: Random Provider Protocol
 
+import CoreGraphics
+
 public protocol RandomProvider {
     func random() -> UInt32
     func random(uniform:UInt32) -> UInt32
@@ -196,7 +198,7 @@ public struct SRandomProvider: RandomProvider {
     }
 
     public func random() -> UInt32 {
-        return UInt32(Darwin.random())
+        return UInt32(random())
     }
 
     public func random(uniform:UInt32) -> UInt32 {

--- a/SwiftGraphics/Random.swift
+++ b/SwiftGraphics/Random.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 schwa.io. All rights reserved.
 //
 
-import Darwin
-
 // MARK: Random Provider Protocol
 
 public protocol RandomProvider {

--- a/SwiftGraphics/Random.swift
+++ b/SwiftGraphics/Random.swift
@@ -223,3 +223,11 @@ public struct SRandomProvider: RandomProvider {
     public let max: UInt32 = 2147483647
 }
 
+// MARK: Random array generator
+
+/// Generate random points within the range.
+public func arrayOfRandomPoints(count:Int, range:CGRect) -> [CGPoint] {
+    return Array <CGPoint> (count:count) {
+        return Random.rng.random(range)
+    }
+}

--- a/SwiftGraphicsPlayground/Utilities.swift
+++ b/SwiftGraphicsPlayground/Utilities.swift
@@ -10,21 +10,6 @@ import CoreGraphics
 
 import SwiftGraphics
 
-extension Array {
-    init(count:Int, block:(Void) -> T) {
-        self.init()
-        for N in 0..<count {
-            append(block())
-        }
-    }
-}
-
-public func arrayOfRandomPoints(count:Int, range:CGRect) -> Array <CGPoint> {
-    return Array <CGPoint> (count:count) {
-        return Random.rng.random(range)
-    }
-}
-
 extension UInt32 {
     func asHex() -> String {
         var s = ""

--- a/SwiftGraphics_OSX_Scratch/GeometryExtensions.swift
+++ b/SwiftGraphics_OSX_Scratch/GeometryExtensions.swift
@@ -41,6 +41,23 @@ extension Circle: CGPathable {
     }
 }
 
+extension Ellipse: CGPathable {
+    var cgpath:CGPath {
+        get {
+            let path = CGPathCreateMutable()
+            let (b1, b2, b3, b4) = self.asBezierCurves
+            
+            path.move(b1.start!)
+            path.addCurve(BezierCurve(controls: b1.controls, end: b1.end))
+            path.addCurve(BezierCurve(controls: b2.controls, end: b2.end))
+            path.addCurve(BezierCurve(controls: b3.controls, end: b3.end))
+            path.addCurve(BezierCurve(controls: b4.controls, end: b4.end))
+            path.close()
+            return path
+        }
+    }
+}
+
 extension Triangle: CGPathable {
     var cgpath:CGPath {
         get {

--- a/SwiftGraphics_OSX_Scratch/ScratchWindowController.swift
+++ b/SwiftGraphics_OSX_Scratch/ScratchWindowController.swift
@@ -53,7 +53,7 @@ class ScratchWindowController: NSWindowController {
         let view = contentViewController!.view
         mouseLocation = view.convertPoint(mouseLocation, fromView: nil)
 
-        mouseLocation = mouseLocation.clamped(view.bounds.insetted(dx: 50, dy: 50))
+        mouseLocation = mouseLocation.clampedTo(view.bounds.insetted(dx: 50, dy: 50))
 
         let thing = Thing(model:model, geometry:geometry)
         thing.center = mouseLocation

--- a/SwiftGraphics_OSX_UITest/HandleEditor/HandleEditorView.swift
+++ b/SwiftGraphics_OSX_UITest/HandleEditor/HandleEditorView.swift
@@ -154,7 +154,7 @@ class LineSegmentObject {
     var lineSegment:LineSegment
 
     init(start:CGPoint, end:CGPoint) {
-        lineSegment = LineSegment(start: start, end: end)
+        lineSegment = LineSegment(start, end)
     }
 }
 
@@ -163,12 +163,12 @@ extension LineSegmentObject : Interactive {
         let startHandle = Handle(position: self.lineSegment.start)
         startHandle.didMove = {
             position in
-            self.lineSegment = LineSegment(start:position, end:self.lineSegment.end)
+            self.lineSegment = LineSegment(position, self.lineSegment.end)
         }
         let endHandle = Handle(position: self.lineSegment.end)
         endHandle.didMove = {
             position in
-            self.lineSegment = LineSegment(start:self.lineSegment.start, end:position)
+            self.lineSegment = LineSegment(self.lineSegment.start, position)
         }
         return [startHandle, endHandle]
     }


### PR DESCRIPTION
It's also useful to generate dynamic shapes for iOS.

Would you like to move geometry extensions from SwiftGraphics_OSX_Scratch to SwiftGraphics? I think the model classes and shape algorithms should be moved to some category of the public target. In other hand, view and controller can stay in OS X target, such as mouse or touch motion dispatching and interactive commands.

Best regards!