### PR TITLE
Add CGPathFromSVGPath() to create path easily.

### DIFF
--- a/SwiftGraphics.xcodeproj/project.pbxproj
+++ b/SwiftGraphics.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		02C9D0121A71D12F00B9696E /* RegularPolygon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C9D0111A71D12F00B9696E /* RegularPolygon.swift */; };
 		02C9D0131A71D12F00B9696E /* RegularPolygon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C9D0111A71D12F00B9696E /* RegularPolygon.swift */; };
 		02C9D0261A724D9C00B9696E /* RegularPolygonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C9D0251A724D9C00B9696E /* RegularPolygonTests.swift */; };
+		02DABB641A8F110F000C8D9F /* CGPathFromSVGPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DABB621A8F110F000C8D9F /* CGPathFromSVGPath.m */; };
+		02DABB651A8F110F000C8D9F /* CGPathFromSVGPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DABB621A8F110F000C8D9F /* CGPathFromSVGPath.m */; };
+		02DABB661A8F110F000C8D9F /* CGPathFromSVGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DABB631A8F110F000C8D9F /* CGPathFromSVGPath.swift */; };
+		02DABB671A8F110F000C8D9F /* CGPathFromSVGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DABB631A8F110F000C8D9F /* CGPathFromSVGPath.swift */; };
 		02E8FBC41A8615B90061D101 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E8FBC31A8615B90061D101 /* Random.swift */; };
 		02E8FBC51A8615B90061D101 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E8FBC31A8615B90061D101 /* Random.swift */; };
 		2E0F5BD91A6986DA00221BB0 /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0F5BD81A6986DA00221BB0 /* ColorTests.swift */; };
@@ -320,6 +324,8 @@
 		02BF437D1A64FACB00132343 /* BezierCurve+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BezierCurve+Extensions.swift"; sourceTree = "<group>"; };
 		02C9D0111A71D12F00B9696E /* RegularPolygon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegularPolygon.swift; sourceTree = "<group>"; };
 		02C9D0251A724D9C00B9696E /* RegularPolygonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegularPolygonTests.swift; sourceTree = "<group>"; };
+		02DABB621A8F110F000C8D9F /* CGPathFromSVGPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CGPathFromSVGPath.m; sourceTree = "<group>"; };
+		02DABB631A8F110F000C8D9F /* CGPathFromSVGPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGPathFromSVGPath.swift; sourceTree = "<group>"; };
 		02E8FBC31A8615B90061D101 /* Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Random.swift; sourceTree = "<group>"; };
 		2E0F5BD81A6986DA00221BB0 /* ColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
 		2E0F5BDA1A69BBA600221BB0 /* QuadrantTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuadrantTests.swift; sourceTree = "<group>"; };
@@ -970,6 +976,8 @@
 				458C590A1A74121600E993A6 /* CGContext+Drawing.swift */,
 				4574C0261A64613A00454DE5 /* CGContext+BitmapContexts.swift */,
 				459EE5DF19AEC5130012E023 /* CGPath.swift */,
+				02DABB631A8F110F000C8D9F /* CGPathFromSVGPath.swift */,
+				02DABB621A8F110F000C8D9F /* CGPathFromSVGPath.m */,
 			);
 			name = Quartz;
 			sourceTree = "<group>";
@@ -1342,6 +1350,7 @@
 				458C59081A7410A500E993A6 /* GeometryProtocols.swift in Sources */,
 				45E38D2C1A74242E00EC672A /* Ellipse+Markup.swift in Sources */,
 				02AAA8ED1A7A16A5001898E2 /* Gradient.swift in Sources */,
+				02DABB661A8F110F000C8D9F /* CGPathFromSVGPath.swift in Sources */,
 				4563EFD91A7E9B7000019643 /* Matrix.swift in Sources */,
 				4594B08B19AEDC2100101EB4 /* SwiftGraphicsHelper.m in Sources */,
 				459EE5F119AEC5130012E023 /* CGRect.swift in Sources */,
@@ -1367,6 +1376,7 @@
 				458C590E1A74136000E993A6 /* Insidedness.swift in Sources */,
 				459EE5ED19AEC5130012E023 /* CGPath.swift in Sources */,
 				45E38D251A74235800EC672A /* Style.swift in Sources */,
+				02DABB641A8F110F000C8D9F /* CGPathFromSVGPath.m in Sources */,
 				456877E219B6857B004BEFD6 /* CoordinateSystems.swift in Sources */,
 				45E38D2E1A74242E00EC672A /* Markup.swift in Sources */,
 				45F32C721A6455BB00E3DA68 /* CGColor.swift in Sources */,
@@ -1485,6 +1495,7 @@
 				458A6D3B1A8455D900DEFBFA /* CGPoint+Trigonometry.swift in Sources */,
 				45F32C731A6455BB00E3DA68 /* CGColor.swift in Sources */,
 				45066CFB1A74347300F561E1 /* Lines.swift in Sources */,
+				02DABB671A8F110F000C8D9F /* CGPathFromSVGPath.swift in Sources */,
 				45E38D2B1A74242E00EC672A /* BezierPath+Markup.swift in Sources */,
 				459EE5FC19AEC5130012E023 /* Utilities.swift in Sources */,
 				4515825D19C9F21800856C91 /* Turn.swift in Sources */,
@@ -1517,6 +1528,7 @@
 				4594B09319AEE31E00101EB4 /* Path.swift in Sources */,
 				45E38D241A74235800EC672A /* Geometry+Drawable.swift in Sources */,
 				459EE5EA19AEC5130012E023 /* CGAffineTransform.swift in Sources */,
+				02DABB651A8F110F000C8D9F /* CGPathFromSVGPath.m in Sources */,
 				45066CFE1A74349500F561E1 /* Lines+Drawing.swift in Sources */,
 				45E38D2D1A74242E00EC672A /* Ellipse+Markup.swift in Sources */,
 				456C315D19C65B0E003AA1DF /* Ellipse.swift in Sources */,

--- a/SwiftGraphics/CGPathFromSVGPath.m
+++ b/SwiftGraphics/CGPathFromSVGPath.m
@@ -1,0 +1,423 @@
+//
+//  CGPathFromSVGPath.m
+//  SwiftGraphics
+//
+//  Created by Zhang Yungui on 2/11/15.
+//  Copyright (c) 2015 schwa.io. All rights reserved.
+//
+
+#import <CoreGraphics/CoreGraphics.h>
+#include <math.h>
+#include <string.h>
+#include <stdlib.h>
+
+static bool svg_isspace(char c) {
+    return strchr(" \t\n\v\f\r", c) != 0;
+}
+
+static bool svg_isdigit(char c) {
+    return strchr("0123456789", c) != 0;
+}
+
+static bool svg_isnum(char c) {
+    return strchr("0123456789+-.eE", c) != 0;
+}
+
+static const char* svg_getNextPathItem(const char* s, char* it)
+{
+    int i = 0;
+    it[0] = '\0';
+    // Skip white spaces and commas
+    while (*s && (svg_isspace(*s) || *s == ',')) s++;
+    if (!*s) return s;
+    if (*s == '-' || *s == '+' || svg_isdigit(*s)) {
+        // sign
+        if (*s == '-' || *s == '+') {
+            if (i < 63) it[i++] = *s;
+            s++;
+        }
+        // integer part
+        while (*s && svg_isdigit(*s)) {
+            if (i < 63) it[i++] = *s;
+            s++;
+        }
+        if (*s == '.') {
+            // decimal point
+            if (i < 63) it[i++] = *s;
+            s++;
+            // fraction part
+            while (*s && svg_isdigit(*s)) {
+                if (i < 63) it[i++] = *s;
+                s++;
+            }
+        }
+        // exponent
+        if (*s == 'e' || *s == 'E') {
+            if (i < 63) it[i++] = *s;
+            s++;
+            if (*s == '-' || *s == '+') {
+                if (i < 63) it[i++] = *s;
+                s++;
+            }
+            while (*s && svg_isdigit(*s)) {
+                if (i < 63) it[i++] = *s;
+                s++;
+            }
+        }
+        it[i] = '\0';
+    } else {
+        // Parse command
+        it[0] = *s++;
+        it[1] = '\0';
+        return s;
+    }
+    
+    return s;
+}
+
+static int svg_getArgsPerElement(char cmd)
+{
+    switch (cmd) {
+        case 'v':
+        case 'V':
+        case 'h':
+        case 'H':
+            return 1;
+        case 'm':
+        case 'M':
+        case 'l':
+        case 'L':
+        case 't':
+        case 'T':
+            return 2;
+        case 'q':
+        case 'Q':
+        case 's':
+        case 'S':
+            return 4;
+        case 'c':
+        case 'C':
+            return 6;
+        case 'a':
+        case 'A':
+            return 7;
+    }
+    return 0;
+}
+
+#if CGFLOAT_IS_DOUBLE
+#define sqrt_ sqrt
+#define acos_ acos
+#define sin_  sin
+#define cos_  cos
+#define fabs_ fabs
+#else
+#define sqrt_ sqrtf
+#define acos_ acosf
+#define sin_  sinf
+#define cos_  cos
+#define fabs_ fabsf
+#endif
+
+static CGFloat svg_sqr(CGFloat x) { return x*x; }
+static CGFloat svg_vmag(CGFloat x, CGFloat y) { return sqrt_(x*x + y*y); }
+
+static CGFloat svg_vecrat(CGFloat ux, CGFloat uy, CGFloat vx, CGFloat vy)
+{
+    return (ux*vx + uy*vy) / (svg_vmag(ux,uy) * svg_vmag(vx,vy));
+}
+
+static CGFloat svg_vecang(CGFloat ux, CGFloat uy, CGFloat vx, CGFloat vy)
+{
+    CGFloat r = svg_vecrat(ux,uy, vx,vy);
+    if (r < -1.0f) r = -1.0f;
+    if (r > 1.0f) r = 1.0f;
+    return ((ux*vy < uy*vx) ? -1.0f : 1.0f) * acos_(r);
+}
+
+static void svg_xformPoint(CGFloat* dx, CGFloat* dy, CGFloat x, CGFloat y, const CGFloat* t)
+{
+    *dx = x*t[0] + y*t[2] + t[4];
+    *dy = x*t[1] + y*t[3] + t[5];
+}
+
+static void svg_xformVec(CGFloat* dx, CGFloat* dy, CGFloat x, CGFloat y, const CGFloat* t)
+{
+    *dx = x*t[0] + y*t[2];
+    *dy = x*t[1] + y*t[3];
+}
+
+static void svg_pathArcTo(CGMutablePathRef path, const CGFloat* args, bool rel)
+{
+    // Ported from canvg (https://code.google.com/p/canvg/)
+    CGFloat rx, ry, rotx;
+    CGFloat x1, y1, x2, y2, cx, cy, dx, dy, d;
+    CGFloat x1p, y1p, cxp, cyp, s, sa, sb;
+    CGFloat ux, uy, vx, vy, a1, da;
+    CGFloat x, y, tanx, tany, a, px=0, py=0, ptanx=0, ptany=0, t[6];
+    CGFloat sinrx, cosrx;
+    int fa, fs;
+    int i, ndivs;
+    CGFloat hda, kappa;
+    CGPoint end = CGPathGetCurrentPoint(path);
+    
+    rx = fabs_(args[0]);				// y radius
+    ry = fabs_(args[1]);				// x radius
+    rotx = args[2] * M_PI / 180.f;      // x rotation engle
+    fa = fabs_(args[3]) > 1e-6 ? 1 : 0;	// Large arc
+    fs = fabs_(args[4]) > 1e-6 ? 1 : 0;	// Sweep direction
+    x1 = end.x;                          // start point
+    y1 = end.y;
+    if (rel) {							// end point
+        x2 = end.x + args[5];
+        y2 = end.y + args[6];
+    } else {
+        x2 = args[5];
+        y2 = args[6];
+    }
+    
+    dx = x1 - x2;
+    dy = y1 - y2;
+    d = sqrt_(dx*dx + dy*dy);
+    if (d < 1e-6f || rx < 1e-6f || ry < 1e-6f) {
+        // The arc degenerates to a line
+        CGPathAddLineToPoint(path, nil, x2, y2);
+        return;
+    }
+    
+    sinrx = sin_(rotx);
+    cosrx = cos_(rotx);
+    
+    // Convert to center point parameterization.
+    // http://www.w3.org/TR/SVG11/implnote.html#ArcImplementationNotes
+    // 1) Compute x1', y1'
+    x1p = cosrx * dx / 2.0f + sinrx * dy / 2.0f;
+    y1p = -sinrx * dx / 2.0f + cosrx * dy / 2.0f;
+    d = svg_sqr(x1p)/svg_sqr(rx) + svg_sqr(y1p)/svg_sqr(ry);
+    if (d > 1) {
+        d = sqrt_(d);
+        rx *= d;
+        ry *= d;
+    }
+    // 2) Compute cx', cy'
+    s = 0.0f;
+    sa = svg_sqr(rx)*svg_sqr(ry) - svg_sqr(rx)*svg_sqr(y1p) - svg_sqr(ry)*svg_sqr(x1p);
+    sb = svg_sqr(rx)*svg_sqr(y1p) + svg_sqr(ry)*svg_sqr(x1p);
+    if (sa < 0.0f) sa = 0.0f;
+    if (sb > 0.0f)
+        s = sqrt_(sa / sb);
+    if (fa == fs)
+        s = -s;
+    cxp = s * rx * y1p / ry;
+    cyp = s * -ry * x1p / rx;
+    
+    // 3) Compute cx,cy from cx',cy'
+    cx = (x1 + x2)/2.0f + cosrx*cxp - sinrx*cyp;
+    cy = (y1 + y2)/2.0f + sinrx*cxp + cosrx*cyp;
+    
+    // 4) Calculate theta1, and delta theta.
+    ux = (x1p - cxp) / rx;
+    uy = (y1p - cyp) / ry;
+    vx = (-x1p - cxp) / rx;
+    vy = (-y1p - cyp) / ry;
+    a1 = svg_vecang(1.0f,0.0f, ux,uy);	// Initial angle
+    da = svg_vecang(ux,uy, vx,vy);		// Delta angle
+    
+    //if (vecrat(ux,uy,vx,vy) <= -1.0f) da = M_PI;
+    //if (vecrat(ux,uy,vx,vy) >= 1.0f) da = 0;
+    
+    if (fa) {
+        // Choose large arc
+        if (da > 0.0f)
+            da = da - M_PI * 2;
+        else
+            da = M_PI * 2 + da;
+    }
+    
+    // Approximate the arc using cubic spline segments.
+    t[0] = cosrx; t[1] = sinrx;
+    t[2] = -sinrx; t[3] = cosrx;
+    t[4] = cx; t[5] = cy;
+    
+    // Split arc into max 90 degree segments.
+    ndivs = (int)(fabs_(da) / M_PI_2 + 0.5f);
+    hda = (da / (CGFloat)ndivs) / 2.0f;
+    kappa = fabs_(4.0f / 3.0f * (1.0f - cos_(hda)) / sin_(hda));
+    if (da < 0.0f)
+        kappa = -kappa;
+    
+    for (i = 0; i <= ndivs; i++) {
+        a = a1 + da * (i/(CGFloat)ndivs);
+        dx = cos_(a);
+        dy = sin_(a);
+        svg_xformPoint(&x, &y, dx*rx, dy*ry, t); // position
+        svg_xformVec(&tanx, &tany, -dy*rx * kappa, dx*ry * kappa, t); // tangent
+        if (i > 0) {
+            if (rel) {
+                CGPathAddCurveToPoint(path, nil, px+ptanx+end.x, py+ptany+end.y,
+                                      x-tanx+end.x, y-tany+end.y, x+end.x, y+end.y);
+            } else {
+                CGPathAddCurveToPoint(path, nil, px+ptanx, py+ptany, x-tanx, y-tany, x, y);
+            }
+        }
+        px = x;
+        py = y;
+        ptanx = tanx;
+        ptany = tany;
+    }
+}
+
+static void svg_pathApplier(void *info, const CGPathElement *element)
+{
+    CGPoint* pts = (CGPoint*)info;
+    int n = 0;
+    
+    switch (element->type) {
+        case kCGPathElementMoveToPoint:
+            pts[0] = element->points[0];
+            pts[1] = pts[0];
+            n = 1;
+            break;
+        case kCGPathElementAddLineToPoint:
+            pts[1] = pts[0];                // last point
+            pts[0] = element->points[0];
+            n = 1;
+            break;
+        case kCGPathElementAddQuadCurveToPoint:
+            n = 2;
+            break;
+        case kCGPathElementAddCurveToPoint:
+            n = 3;
+            break;
+        default:
+            break;
+    }
+    if (n > 1) {
+        for (int i = 0; i < n; ++i) {       // pts[0]: end point
+            pts[i] = element->points[n - i - 1];
+        }
+    }
+}
+
+static CGPoint svg_outControlPoint(CGMutablePathRef path)
+{
+    CGPoint pts[3] = { CGPointZero, CGPointZero, CGPointZero };
+    CGPathApply(path, pts, svg_pathApplier);
+    return CGPointMake(2 * pts[0].x - pts[1].x, 2 * pts[0].y - pts[1].y);
+}
+
+// Convert path string as the ‘d’ attribute of SVG path to CGPath.
+// The path string, as the ‘d’ attribute of SVG path, begins with a ‘M’ character and can contain
+// instructions as described in http://www.w3.org/TR/SVGTiny12/paths.html
+
+void CGPathFromSVGPath(CGMutablePathRef path, const char* s)
+{
+    char item[64];
+    char cmd = 0;
+    CGFloat args[10] = { 0, 0, 0, 0, 0, 0 };
+    int nargs = 0;
+    int rargs = 0;
+    CGPoint end;
+    
+    while (*s) {
+        s = svg_getNextPathItem(s, item);
+        if (!*item) break;
+        if (!svg_isnum(item[0])) {
+            cmd = item[0];
+            rargs = svg_getArgsPerElement(cmd);
+            nargs = 0;
+            if (cmd == 'Z' || cmd == 'z') {
+                CGPathCloseSubpath(path);
+            }
+        } else {
+            if (nargs < 10)
+                args[nargs++] = atof(item);
+            if (nargs >= rargs) {
+                switch (cmd) {
+                    case 'm':
+                    case 'M':
+                        if (cmd == 'm') {
+                            end = CGPathGetCurrentPoint(path);
+                            CGPathMoveToPoint(path, nil, args[0]+end.x, args[1]+end.y);
+                        } else {
+                            CGPathMoveToPoint(path, nil, args[0], args[1]);
+                        }
+                        // Moveto can be followed by multiple coordinate pairs,
+                        // which should be treated as linetos.
+                        cmd = (cmd == 'm') ? 'l' : 'L';
+                        rargs = svg_getArgsPerElement(cmd);
+                        break;
+                    case 'l':
+                    case 'L':
+                        if (cmd == 'l') {
+                            end = CGPathGetCurrentPoint(path);
+                            CGPathAddLineToPoint(path, nil, args[0]+end.x, args[1]+end.y);
+                        } else {
+                            CGPathAddLineToPoint(path, nil, args[0], args[1]);
+                        }
+                        break;
+                    case 'H':
+                    case 'h':
+                        end = CGPathGetCurrentPoint(path);
+                        CGPathAddLineToPoint(path, nil, cmd == 'h' ? args[0] + end.x : args[0], end.y);
+                        break;
+                    case 'V':
+                    case 'v':
+                        end = CGPathGetCurrentPoint(path);
+                        CGPathAddLineToPoint(path, nil, end.x, cmd == 'v' ? args[0] + end.y : args[0]);
+                        break;
+                    case 'C':
+                    case 'c':
+                        if (cmd == 'c') {
+                            end = CGPathGetCurrentPoint(path);
+                            CGPathAddCurveToPoint(path, nil, args[0]+end.x, args[1]+end.y,
+                                                  args[2]+end.x, args[3]+end.y, args[4]+end.x, args[5]+end.y);
+                        } else {
+                            CGPathAddCurveToPoint(path, nil, args[0], args[1], args[2], args[3], args[4], args[5]);
+                        }
+                        break;
+                    case 'S':
+                    case 's': {
+                        CGPoint cp1 = svg_outControlPoint(path);
+                        if (cmd == 's') {
+                            end = CGPathGetCurrentPoint(path);
+                            CGPathAddCurveToPoint(path, nil, cp1.x, cp1.y, args[0]+end.x, args[1]+end.y,
+                                                  args[2]+end.x, args[3]+end.y);
+                        } else {
+                            CGPathAddCurveToPoint(path, nil, cp1.x, cp1.y, args[0], args[1], args[2], args[3]);
+                        }
+                        break;
+                    }
+                    case 'Q':
+                    case 'q':
+                        if (cmd == 'q') {
+                            end = CGPathGetCurrentPoint(path);
+                            CGPathAddQuadCurveToPoint(path, nil, args[0]+end.x, args[1]+end.y,
+                                                      args[2]+end.x, args[3]+end.y);
+                        } else {
+                            CGPathAddQuadCurveToPoint(path, nil, args[0], args[1], args[2], args[3]);
+                        }
+                        break;
+                    case 'T':
+                    case 't': {
+                        CGPoint cp1 = svg_outControlPoint(path);
+                        if (cmd == 't') {
+                            end = CGPathGetCurrentPoint(path);
+                            CGPathAddQuadCurveToPoint(path, nil, cp1.x, cp1.y, args[0]+end.x, args[1]+end.y);
+                        } else {
+                            CGPathAddQuadCurveToPoint(path, nil, cp1.x, cp1.y, args[0], args[1]);
+                        }
+                        break;
+                    }
+                    case 'A':
+                    case 'a':
+                        svg_pathArcTo(path, args, cmd == 'a' ? 1 : 0);
+                        break;
+                    default:
+                        break;
+                }
+                nargs = 0;
+            }
+        }
+    }
+}

--- a/SwiftGraphics/CGPathFromSVGPath.swift
+++ b/SwiftGraphics/CGPathFromSVGPath.swift
@@ -1,0 +1,27 @@
+//
+//  CGPathFromSVGPath.swift
+//  SwiftGraphics
+//
+//  Created by Zhang Yungui on 2/11/15.
+//  Copyright (c) 2015 schwa.io. All rights reserved.
+//
+
+import CoreGraphics
+
+/**
+ Convenience function to create path from string like SVG path element.
+
+ :param: d path string as the ‘d’ attribute of SVG path. It begins with a ‘M’ character and can contain
+           instructions ‘MmLlCcQqSsTtZz’ as described in http://www.w3.org/TR/SVGTiny12/paths.html
+
+ :test:   CGPathFromSVG("M20,50 Q40,5 100,50").endPoint
+ :result: CGPoint((100,50))
+
+ :return: the new path.
+ */
+public func CGPathFromSVGPath(d:String) -> CGMutablePath
+{
+    let path = CGPathCreateMutable()
+    CGPathFromSVGPath(path, d)
+    return path
+}

--- a/SwiftGraphics/SwiftGraphicsHelper.h
+++ b/SwiftGraphics/SwiftGraphicsHelper.h
@@ -11,3 +11,5 @@
 typedef void (^CGPathApplierBlock)(const CGPathElement *element);
 
 extern void CGPathApplyWithBlock(CGPathRef inPath, CGPathApplierBlock block);
+
+extern void CGPathFromSVGPath(CGMutablePathRef inPath, const char* s);


### PR DESCRIPTION
For example:
`let path = CGPathFromSVGPath("M120,70 C0,200 150,375 250,220 T500,220")`
equals to:
```
var path = CGPathCreateMutable()
path.move(CGPoint(x:120, y:70))
path.addCubicCurveToPoint(CGPoint(x:250, y:220),
    control1:CGPoint(x:0, y:200), control2:CGPoint(x:150, y:375))
path.addSmoothQuadCurveToPoint(CGPoint(x:500, y:220))
```

Five-pointed star: `CGPathFromSVGPath("M100,0 L41.22,180.9 195.1,69.09 4.89,69.09 158.77,180.9z")`