### PR TITLE
Add SwiftGraphics to CocoaPods

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,6 +61,35 @@ SwiftGraphics is made up of:
 * A Mac OS X testbed app “SwiftGraphics_OSX_UITest” that highlights some of the more interactive code
 * Unit Test Targets
 
+## Installation
+
+You can add SwiftGraphics in your project as one of the following ways:
+
+- Add SwiftGraphics.xcodeproj to your project and set up your dependencies appropriately.
+  You can add SwiftGraphics as a submodule by opening the Terminal, trying to enter the command:
+  
+  ```sh
+  git submodule add https://github.com/schwa/SwiftGraphics.git
+  ```
+
+- Install with CocoaPods [v0.36.0+][CocoaPods beta] and add the following to your project Podfile:
+
+  ```
+  platform :ios, '8.0'
+  use_frameworks!
+  pod 'SwiftGraphics/iOS'
+  ```
+  
+  or
+  
+  ```
+  platform :osx, '10.9'
+  use_frameworks!
+  pod 'SwiftGraphics/OSX'
+  ```
+
+[CocoaPods beta]: https://github.com/CocoaPods/swift
+
 ## Usage
 
 SwiftGraphics builds iOS and OS X frameworks. Just add SwiftGraphics.xcodeproj to your project and set up your dependencies appropriately.

--- a/README.markdown
+++ b/README.markdown
@@ -13,9 +13,14 @@ Also note this project is moving to Swift 1.2, which requires Xcode 6.3 and Mac 
 ## Bringing Swift goodness to Quartz.
 
 [![Travis][travis_img]][travis]
+[![Version][podver_img]][podver_url]
+[![Platform][platform_img]][podver_url]
 
 [travis]: https://travis-ci.org/schwa/SwiftGraphics
 [travis_img]: https://travis-ci.org/schwa/SwiftGraphics.svg?branch=master
+[podver_url]: http://cocoadocs.org/docsets/SwiftGraphics
+[podver_img]: https://img.shields.io/cocoapods/v/SwiftGraphics.svg
+[platform_img]: https://img.shields.io/cocoapods/p/SwiftGraphics.svg
 
 See "Help Wanted" section of this document for how you can contribute to SwiftGraphics.
 

--- a/SwiftGraphics.podspec
+++ b/SwiftGraphics.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+
+  s.name         = 'SwiftGraphics'
+  s.version      = '0.0.2'
+  s.summary      = 'Bringing Swift goodness to Quartz.'
+  s.homepage     = 'https://github.com/schwa/SwiftGraphics'
+  s.license      = { :type => 'BSD', :file => 'LICENSE' }
+  s.author       = { 'Jonathan Wight' => 'schwa@toxicsoftware.com' }
+  s.source       = { :git => 'https://github.com/schwa/SwiftGraphics.git', :tag => s.version }
+
+  s.requires_arc = true
+  s.subspec 'Core' do |cs|
+    cs.source_files = 'SwiftGraphics/*.{h,m,mm,swift}'
+    cs.ios.deployment_target = '8.0'
+    cs.osx.deployment_target = '10.9'
+  end
+  s.subspec 'iOS' do |is|
+    is.platform = 'ios'
+    is.ios.deployment_target = '8.0'
+    is.source_files = 'SwiftGraphics_iOS/*.{h,m,swift}'
+    is.dependency 'SwiftGraphics/Core'
+  end
+  s.subspec 'OSX' do |xs|
+    xs.platform = 'osx'
+    xs.osx.deployment_target = '10.9'
+    xs.source_files = 'SwiftGraphics_OSX/*.{h,m,swift}'
+    xs.dependency 'SwiftGraphics/Core'
+  end
+end


### PR DESCRIPTION
Would you like to add SwiftGraphics to CocoaPods?  I've tested it in an app project with CocoaPod 0.36.0. You can push SwiftGraphics.podspec to CocoaPods master and add badges in README as your wish.

## Push the podspec to CocoaPods master please

[SwiftGraphics.podspec][podspec] will be located at `Specs/SwiftGraphics/0.0.2/`.
[podspec]: https://github.com/rhcad/SwiftGraphics/raw/pod/SwiftGraphics.podspec

## Add badges in README as your wish

You can add the following badge images as your wish after the podspec pushed to CocoaPods master.

[![Travis][travis_img]][travis]
[![Version][version_img]][version_url]
[![Platform][platform_img]][version_url]

[travis]: https://travis-ci.org/schwa/SwiftGraphics
[travis_img]: https://travis-ci.org/schwa/SwiftGraphics.svg?branch=master
[version_url]: http://cocoadocs.org/docsets/SwiftGraphics
[version_img]: https://img.shields.io/cocoapods/v/SwiftGraphics.svg
[platform_img]: https://img.shields.io/cocoapods/p/SwiftGraphics.svg

## Podfile test case for one target

The Podfile of my testing project which contains only one target (or for the same platform):

```
platform :ios, 8.0
source 'https://github.com/CocoaPods/Specs.git'
use_frameworks!

pod 'SwiftGraphics/iOS'
```

## Podfile test case for multiple targets

The Podfile of my testing project which contains two targets:

```
# Type `pod update` or `pod update --no-repo-update` to update Pods.

source 'https://github.com/CocoaPods/Specs.git'
use_frameworks!

target 'TestSG_iOS', :exclusive => true do
  platform :ios, 8.0
  pod 'SwiftGraphics/iOS'
end
target 'TestSG_OSX', :exclusive => true do
  platform :osx, 10.9
  pod 'SwiftGraphics/OSX'
end
```