### PR TITLE
Fix for CocoaPods and update README for Carthage.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,12 +15,15 @@ Also note this project is moving to Swift 1.2, which requires Xcode 6.3 and Mac 
 [![Travis][travis_img]][travis]
 [![Version][podver_img]][podver_url]
 [![Platform][platform_img]][podver_url]
+[![Carthage][carthage_img]][carthage_url]
 
 [travis]: https://travis-ci.org/schwa/SwiftGraphics
 [travis_img]: https://travis-ci.org/schwa/SwiftGraphics.svg?branch=master
 [podver_url]: http://cocoadocs.org/docsets/SwiftGraphics
 [podver_img]: https://img.shields.io/cocoapods/v/SwiftGraphics.svg
 [platform_img]: https://img.shields.io/cocoapods/p/SwiftGraphics.svg
+[carthage_img]: https://img.shields.io/badge/Carthage-compatible-4BC51D.svg
+[carthage_url]: https://github.com/Carthage/Carthage
 
 See "Help Wanted" section of this document for how you can contribute to SwiftGraphics.
 
@@ -76,6 +79,12 @@ You can add SwiftGraphics in your project as one of the following ways:
   ```sh
   git submodule add https://github.com/schwa/SwiftGraphics.git
   ```
+
+- Install with [Carthage][carthage_url] (Recommended):
+ 
+  1. Add `github "schwa/SwiftGraphics"` to your project Cartfile.
+  2. Run `carthage update` to download and build SwiftGraphics.
+  3. Drag SwiftGraphics.framework to your project and link it.
 
 - Install with CocoaPods [v0.36.0+][CocoaPods beta] and add the following to your project Podfile:
 

--- a/SwiftGraphics.podspec
+++ b/SwiftGraphics.podspec
@@ -6,24 +6,28 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/schwa/SwiftGraphics'
   s.license      = { :type => 'BSD', :file => 'LICENSE' }
   s.author       = { 'Jonathan Wight' => 'schwa@toxicsoftware.com' }
-  s.source       = { :git => 'https://github.com/schwa/SwiftGraphics.git', :tag => s.version }
+  s.social_media_url = 'https://twitter.com/schwa'
+  s.source       = { :git => 'https://github.com/schwa/SwiftGraphics.git', :branch => 'develop' }
 
   s.requires_arc = true
   s.subspec 'Core' do |cs|
     cs.source_files = 'SwiftGraphics/*.{h,m,mm,swift}'
     cs.ios.deployment_target = '8.0'
     cs.osx.deployment_target = '10.9'
+    cs.frameworks = "CoreGraphics", "Foundation"
   end
   s.subspec 'iOS' do |is|
     is.platform = 'ios'
     is.ios.deployment_target = '8.0'
     is.source_files = 'SwiftGraphics_iOS/*.{h,m,swift}'
     is.dependency 'SwiftGraphics/Core'
+    is.frameworks = "UIKit"
   end
   s.subspec 'OSX' do |xs|
     xs.platform = 'osx'
     xs.osx.deployment_target = '10.9'
     xs.source_files = 'SwiftGraphics_OSX/*.{h,m,swift}'
     xs.dependency 'SwiftGraphics/Core'
+    xs.frameworks = "AppKit"
   end
 end


### PR DESCRIPTION
Add frameworks to the podspec to avoid linking errors in framework project.
Add badge image and update README for Carthage.

Using SwiftGraphics with Carthage is really easier than CocoaPods! Thank you for your example project!