### PR TITLE
Add transformVector(). Add comment for angleTo().

### DIFF
--- a/SwiftGraphics/CGAffineTransform.swift
+++ b/SwiftGraphics/CGAffineTransform.swift
@@ -237,6 +237,14 @@ public func *= (inout lhs:CGRect, rhs:CGAffineTransform) {
     lhs = CGRectApplyAffineTransform(lhs, rhs)
 }
 
+// MARK: Transform a vector
+
+public extension CGAffineTransform {
+    func transformVector(vec:CGPoint) -> CGPoint {
+        return CGPoint(x:vec.x * a + vec.y * d, y:vec.x * c + vec.y * d);
+    }
+}
+
 // MARK: Converting transforms to/from arrays
 
 public extension CGAffineTransform {

--- a/SwiftGraphics/CGPoint+Trigonometry.swift
+++ b/SwiftGraphics/CGPoint+Trigonometry.swift
@@ -106,7 +106,8 @@ public extension CGPoint {
         return (distanceTo(perp), perp)
     }
 
-    // TODO: This should be identical to atan2() and it isn't!
+    // Returns the angle between this vector and another vector 'vec'.
+    // The result sign indicates the rotation direction from this vector to 'vec': positive for counter-clockwise, negative for clockwise.
     func angleTo(vec:CGPoint) -> CGFloat {       // [-M_PI, M_PI)
         return atan2(crossProduct(self, vec), dotProduct(self, vec))
     }


### PR DESCRIPTION
1. Transform a vector

    It's diffrent between point and vector in geometry, but now CGPoint is used to represent both point and vector. The function `func * (lhs:CGPoint, rhs:CGAffineTransform) -> CGPoint` is used for point apparently. We need a function to transform a vector, which need't the translation elements of CGAffineTransform.

2. The comment of angleTo

    I noticed the TODO comment in CGPoint+Trigonometry.swift, so I add comment for angleTo(). `TODO: This should be identical to atan2() and it isn't!`

Please review. Thank you!