### PR TITLE
Previous failing tests in RegularPolygonTests now fixed from #42 patch

### DIFF
--- a/SwiftGraphics.xcodeproj/project.pbxproj
+++ b/SwiftGraphics.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		45FA46521A7F3DBB000473B5 /* Rectangle+Markup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FA46501A7F3DBB000473B5 /* Rectangle+Markup.swift */; };
 		45FA46541A7F3EA9000473B5 /* Circle+Markup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FA46531A7F3EA9000473B5 /* Circle+Markup.swift */; };
 		45FA46551A7F3EA9000473B5 /* Circle+Markup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FA46531A7F3EA9000473B5 /* Circle+Markup.swift */; };
+		938BCB851B801E3D00C82F1E /* TriangleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F42FF31B7E9C91005D2ADA /* TriangleTests.swift */; };
 		93F42FF41B7E9C91005D2ADA /* TriangleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F42FF31B7E9C91005D2ADA /* TriangleTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -1077,6 +1078,7 @@
 				451D291A1A8A920800209FE3 /* TransformTests.swift in Sources */,
 				451D291E1A8A920800209FE3 /* UtilitiesTests.swift in Sources */,
 				451D29161A8A920800209FE3 /* RegularPolygonTests.swift in Sources */,
+				938BCB851B801E3D00C82F1E /* TriangleTests.swift in Sources */,
 				451D291C1A8A920800209FE3 /* ColorTests.swift in Sources */,
 				451D291B1A8A920800209FE3 /* ConvexHullTests.swift in Sources */,
 			);

--- a/SwiftGraphics_UnitTests/RegularPolygonTests.swift
+++ b/SwiftGraphics_UnitTests/RegularPolygonTests.swift
@@ -38,14 +38,12 @@ class RegularPolygonTests: XCTestCase {
         XCTAssertEqualWithAccuracy(p.center.x, t.circumcenter.x, accuracy: tolerance)
         XCTAssertEqualWithAccuracy(p.center.y, t.circumcenter.y, accuracy: tolerance)
         
-        // TODO: There are some issues in Triangle class, so comment the following lines.
         XCTAssertEqualWithAccuracy(p.area, t.area, accuracy: tolerance)
         XCTAssertEqualWithAccuracy(p.circumcircle.radius, t.circumcircle.radius, accuracy: tolerance)
         XCTAssertEqualWithAccuracy(p.inradius, t.inradius, accuracy: tolerance)
-        //XCTAssertEqualWithAccuracy(p.center.x, t.incenter.x, tolerance)
-        //XCTAssertEqualWithAccuracy(p.center.y, t.incenter.y, tolerance)
-// TODO: Comment out the following line to crash Swift 1.2b2 (Apple Swift version 1.2)
-//        XCTAssertEqualWithAccuracy(p.length, {let s=t.lengths; return s.0+s.1+s.2}(), tolerance)
+        XCTAssertEqualWithAccuracy(p.center.x, t.incenter.x, accuracy: tolerance)
+        XCTAssertEqualWithAccuracy(p.center.y, t.incenter.y, accuracy: tolerance)
+        XCTAssertEqualWithAccuracy(p.length, {let s=t.lengths; return s.0+s.1+s.2}(), accuracy: tolerance)
     }
 
 }


### PR DESCRIPTION
I also realized that the TriangleTests were not added to the iOS target. Snuck that in with this PR.