### PR TITLE
Make context transformation applicable to closure only

### DIFF
--- a/SwiftGraphics/Quartz/CGContext.swift
+++ b/SwiftGraphics/Quartz/CGContext.swift
@@ -65,8 +65,10 @@ public extension CGContext {
 
     func with(transform: CGAffineTransform, @noescape block: () -> Void) {
         with() {
+            CGContextSaveGState(self)
             CGContextConcatCTM(self, transform)
             block()
+            CGContextRestoreGState(self)
         }
     }
 


### PR DESCRIPTION
The graphics state saves the current context transformation state as well as the state of the styles. Wrapping the transformation within a GState is appropriate.